### PR TITLE
fix(ci): drop invalid --yes flag from d1 migrations apply

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,7 +54,7 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: bunx wrangler d1 migrations apply bulma --remote --yes --env production
+        run: bunx wrangler d1 migrations apply bulma --remote --env production
 
       - name: Push Worker secrets (api only)
         if: ${{ inputs.APP_NAME == 'api' }}


### PR DESCRIPTION
wrangler rejects `Unknown argument: yes`; CI is non-interactive so the confirmation prompt is auto-skipped. Unblocks the failed prod deploy (api-deploy D1 migration step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)