### PR TITLE
fix: mandatory referral code + BlindPay webhook payload parsing

### DIFF
--- a/apps/api/scripts/seed-bootstrap-codes.sql
+++ b/apps/api/scripts/seed-bootstrap-codes.sql
@@ -1,0 +1,11 @@
+-- One-off: seed 5 ownerless bootstrap referral codes so the first friends can
+-- onboard now that a referral code is mandatory. Ownerless => no credit awarded
+-- on conversion (matches the original INITIAL bootstrap pattern).
+-- Apply once against prod D1:
+--   wrangler d1 execute bulma --env production --remote --file scripts/seed-bootstrap-codes.sql
+INSERT INTO referral_codes (id, owner_user_id, code, status, created_at) VALUES
+  ('rc_9utNbs2wbb1D', NULL, '7P44RD', 'available', 1780191720),
+  ('rc_U21hm2ERVHY0', NULL, 'BEUXGP', 'available', 1780191720),
+  ('rc_BiHUnbL7nkTj', NULL, '89DKRA', 'available', 1780191720),
+  ('rc_Yl_c6Tp0fCtE', NULL, '8FG4UE', 'available', 1780191720),
+  ('rc_ZGA4Wt-2ySq7', NULL, 'R32K8U', 'available', 1780191720);

--- a/apps/api/src/routes/onboard.ts
+++ b/apps/api/src/routes/onboard.ts
@@ -1,7 +1,7 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi"
 import { eq } from "drizzle-orm"
 import { drizzle } from "drizzle-orm/d1"
-import { userProfile } from "../db/schema"
+import { userProfile, referralCodes } from "../db/schema"
 import { createBlindPay, BlindPayError } from "../lib/blindpay"
 import { attachReferralCode } from "../lib/referrals"
 import { requireUser, type AuthContext } from "../middleware/require-user"
@@ -69,7 +69,7 @@ const startRoute = createRoute({
     },
     400: {
       content: { "application/json": { schema: ErrorResponse } },
-      description: "Invalid / self referral code",
+      description: "Missing / invalid / self referral code",
     },
     409: {
       content: { "application/json": { schema: ErrorResponse } },
@@ -103,15 +103,25 @@ onboard.openapi(startRoute, async (c) => {
     return c.json({ state: "ready" as const }, 200)
   }
 
-  // Optional referral code: attach this user as the referee (converts on ready).
-  const body = (await c.req.json().catch(() => ({}))) as {
-    referralCode?: unknown
-  }
-  const referralCode =
-    typeof body.referralCode === "string"
-      ? body.referralCode.trim().toUpperCase()
-      : undefined
-  if (referralCode) {
+  // Mandatory referral: every new user must attach a valid code before KYC.
+  // A user who already attached on an earlier /start (re-running while pending)
+  // is exempt — they don't need to re-supply the code.
+  const alreadyAttached = await db
+    .select({ id: referralCodes.id })
+    .from(referralCodes)
+    .where(eq(referralCodes.convertedUserId, user.id))
+    .get()
+  if (!alreadyAttached) {
+    const body = (await c.req.json().catch(() => ({}))) as {
+      referralCode?: unknown
+    }
+    const referralCode =
+      typeof body.referralCode === "string"
+        ? body.referralCode.trim().toUpperCase()
+        : undefined
+    if (!referralCode) {
+      return c.json({ error: "referral_required" }, 400)
+    }
     const result = await attachReferralCode(db, referralCode, user.id)
     if (result === "self_referral") {
       return c.json({ error: "self_referral" }, 400)

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -97,10 +97,15 @@ webhooks.openapi(route, async (c) => {
     return c.json({ error: "malformed_payload" }, 400)
   }
 
-  const eventType =
-    typeof event === "object" && event !== null && "event_type" in event
-      ? String((event as { event_type: unknown }).event_type)
-      : "unknown"
+  // BlindPay sends a flat payload with the event type in `webhook_event`
+  // (e.g. "receiver.update"). Accept `event_type` too for forward-compat.
+  const eventRecord =
+    typeof event === "object" && event !== null
+      ? (event as Record<string, unknown>)
+      : {}
+  const eventType = String(
+    eventRecord.webhook_event ?? eventRecord.event_type ?? "unknown",
+  )
 
   await db.insert(webhookEvents).values({
     id: svixId,
@@ -165,17 +170,19 @@ async function dispatch(
   }
 }
 
-const ReceiverEventSchema = z.object({
-  event_type: z.string(),
-  data: z
-    .object({
-      id: z.string(),
-      email: z.string().email().optional(),
-      kyc_status: z.enum(["verifying", "approved", "rejected"]).optional(),
-      country: z.string().optional(),
-    })
-    .passthrough(),
-})
+// BlindPay receiver payloads are flat: the receiver object's fields sit at the
+// top level of the webhook body (no `data` envelope). kyc_status is read as a
+// free string and narrowed below so an unmodeled status can't fail the parse.
+const ReceiverEventSchema = z
+  .object({
+    id: z.string(),
+    email: z.string().email().optional(),
+    kyc_status: z.string().optional(),
+    country: z.string().optional(),
+  })
+  .passthrough()
+
+const KYC_STATES = ["verifying", "approved", "rejected"] as const
 
 async function onReceiverEvent(
   event: unknown,
@@ -185,7 +192,7 @@ async function onReceiverEvent(
   const parsed = ReceiverEventSchema.safeParse(event)
   if (!parsed.success) return
 
-  const { data } = parsed.data
+  const data = parsed.data
   const userId = await findUserIdForReceiver(data, db)
   if (!userId) {
     console.warn("webhook: no matching user for receiver", {
@@ -194,12 +201,18 @@ async function onReceiverEvent(
     return
   }
 
+  const kycStatus = (KYC_STATES as readonly string[]).includes(
+    data.kyc_status ?? "",
+  )
+    ? (data.kyc_status as (typeof KYC_STATES)[number])
+    : undefined
+
   await applyReceiverStateForUser(
     userId,
     {
       id: data.id,
       email: data.email,
-      kyc_status: data.kyc_status,
+      kyc_status: kycStatus,
       country: data.country,
     },
     env,
@@ -207,15 +220,13 @@ async function onReceiverEvent(
   )
 }
 
-const PayoutEventSchema = z.object({
-  event_type: z.string(),
-  data: z
-    .object({
-      id: z.string(),
-      status: z.string().optional(),
-    })
-    .passthrough(),
-})
+// Flat payload (see ReceiverEventSchema): payout fields at the top level.
+const PayoutEventSchema = z
+  .object({
+    id: z.string(),
+    status: z.string().optional(),
+  })
+  .passthrough()
 
 // payout.new/update/complete → flip the local payout's status. Only our own
 // tracked payouts (by `po_` id) are updated; unknown ids are ignored.
@@ -225,7 +236,7 @@ async function onPayoutEvent(
 ): Promise<void> {
   const parsed = PayoutEventSchema.safeParse(event)
   if (!parsed.success) return
-  const { data } = parsed.data
+  const data = parsed.data
   if (!data.status) return
 
   // Guard against out-of-order events clobbering a terminal status. Once a
@@ -251,9 +262,10 @@ async function onPayoutEvent(
   }
 }
 
-const TosEventSchema = z.object({
-  data: z.object({ receiver_id: z.string().optional() }).passthrough(),
-})
+// Flat payload (see ReceiverEventSchema): receiver_id at the top level.
+const TosEventSchema = z
+  .object({ receiver_id: z.string().optional() })
+  .passthrough()
 
 async function onTosAccept(
   event: unknown,

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -101,7 +101,7 @@ webhooks.openapi(route, async (c) => {
   // (e.g. "receiver.update"). Accept `event_type` too for forward-compat.
   const eventRecord =
     typeof event === "object" && event !== null
-      ? (event as Record<string, unknown>)
+      ? event as Record<string, unknown>
       : {}
   const eventType = String(
     eventRecord.webhook_event ?? eventRecord.event_type ?? "unknown",
@@ -204,7 +204,7 @@ async function onReceiverEvent(
   const kycStatus = (KYC_STATES as readonly string[]).includes(
     data.kyc_status ?? "",
   )
-    ? (data.kyc_status as (typeof KYC_STATES)[number])
+    ? data.kyc_status as typeof KYC_STATES[number]
     : undefined
 
   await applyReceiverStateForUser(

--- a/apps/api/tests/onboard-start.test.ts
+++ b/apps/api/tests/onboard-start.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test"
+import { drizzle } from "drizzle-orm/d1"
+import { eq } from "drizzle-orm"
+import { referralCodes, userProfile } from "../src/db/schema"
+import { freshDb } from "./helpers/d1"
+
+// --- Auth: stub createAuth so requireUser yields a fixed user. Must be mocked
+// before importing the route. ---
+const USER_ID = "us_referee00001"
+const OWNER_ID = "us_owner000001"
+const SESSION = {
+  user: { id: USER_ID, email: "referee@bul.ma", name: "Referee" },
+  session: { id: "se_x", token: "t", userId: USER_ID, expiresAt: new Date() },
+}
+mock.module("../src/lib/auth", () => ({
+  createAuth: () => ({ api: { getSession: async () => SESSION } }),
+}))
+
+const { onboard } = await import("../src/routes/onboard")
+
+// --- BlindPay upstream: a controllable global fetch. The mandatory-referral
+// gate must reject *before* this is ever called. ---
+let fetchCalls = 0
+globalThis.fetch = ((async () => {
+  fetchCalls++
+  return new Response(JSON.stringify({ token: "tok_test" }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  })
+}) as typeof fetch)
+
+function nowSec() {
+  return Math.floor(Date.now() / 1000)
+}
+
+let db: ReturnType<typeof drizzle>
+let env: Record<string, unknown>
+
+beforeEach(() => {
+  const fresh = freshDb()
+  db = drizzle(fresh.DB)
+  fetchCalls = 0
+  env = {
+    DB: fresh.DB,
+    ENVIRONMENT: "test",
+    LOG_LEVEL: "fatal",
+    BLINDPAY_API_URL: "https://blindpay.test/v1",
+    BLINDPAY_INSTANCE_ID: "in_test",
+    BLINDPAY_API_KEY: "key",
+    BLINDPAY_HOSTED_INVITE_URL: "https://invite.test/start",
+  }
+})
+
+function start(body: unknown) {
+  return onboard.request(
+    "/start",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json", Authorization: "Bearer t" },
+      body: JSON.stringify(body),
+    },
+    env,
+  )
+}
+
+async function seedCode(code: string, over: Record<string, unknown> = {}) {
+  await db.insert(referralCodes).values({
+    id: `rc_${code}`,
+    ownerUserId: OWNER_ID,
+    code,
+    status: "available",
+    createdAt: nowSec(),
+    ...over,
+  })
+}
+
+describe("POST /onboard/start — mandatory referral", () => {
+  it("rejects a new user with no referral code (400, no BlindPay call)", async () => {
+    const res = await start({})
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ error: "referral_required" })
+    expect(fetchCalls).toBe(0)
+  })
+
+  it("rejects an unknown referral code", async () => {
+    const res = await start({ referralCode: "ZZZZZZ" })
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ error: "invalid_referral_code" })
+    expect(fetchCalls).toBe(0)
+  })
+
+  it("attaches a valid code and proceeds to KYC", async () => {
+    await seedCode("ABCDEF")
+    const res = await start({ referralCode: "abcdef" })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ state: "pending" })
+    expect(fetchCalls).toBe(1)
+    const row = await db
+      .select()
+      .from(referralCodes)
+      .where(eq(referralCodes.code, "ABCDEF"))
+      .get()
+    expect(row?.convertedUserId).toBe(USER_ID)
+    expect(row?.status).toBe("shared")
+  })
+
+  it("exempts a user who already attached a code on re-run with no code", async () => {
+    await seedCode("ABCDEF", { status: "shared", convertedUserId: USER_ID })
+    const res = await start({})
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ state: "pending" })
+    expect(fetchCalls).toBe(1)
+  })
+})

--- a/apps/api/tests/webhooks-dispatch.test.ts
+++ b/apps/api/tests/webhooks-dispatch.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it } from "bun:test"
+import { drizzle } from "drizzle-orm/d1"
+import { eq } from "drizzle-orm"
+import { userProfile, webhookEvents } from "../src/db/schema"
+import { computeSvixSignature } from "../src/lib/svix"
+import { webhooks } from "../src/routes/webhooks"
+import { freshDb } from "./helpers/d1"
+
+// Regression: BlindPay sends a FLAT payload with the event type in
+// `webhook_event` (not a nested `{ event_type, data }`). The old code read
+// `event_type` + `data.*`, so every event landed as "unknown" and was dropped
+// silently — leaving approved users stuck at `pending`. These tests pin the
+// real wire format.
+
+const SECRET = "whsec_plJ3nmyCDGBKInavdOK15jsl"
+const USER_ID = "us_gui00000001"
+const RECEIVER_ID = "re_2DWix15QAqCq"
+
+let db: ReturnType<typeof drizzle>
+let env: Record<string, unknown>
+
+function nowSec() {
+  return Math.floor(Date.now() / 1000)
+}
+
+beforeEach(async () => {
+  const fresh = freshDb()
+  db = drizzle(fresh.DB)
+  env = {
+    DB: fresh.DB,
+    ENVIRONMENT: "test",
+    LOG_LEVEL: "fatal",
+    BLINDPAY_WEBHOOK_SECRET: SECRET,
+  }
+  await db.insert(userProfile).values({
+    userId: USER_ID,
+    onboardingState: "pending",
+    receiverId: RECEIVER_ID,
+    createdAt: nowSec(),
+  })
+})
+
+async function postWebhook(payloadObj: unknown) {
+  const payload = JSON.stringify(payloadObj)
+  const ts = String(nowSec())
+  const msgId = "msg_test00000001"
+  const sig = await computeSvixSignature({
+    msgId,
+    timestamp: ts,
+    payload,
+    secret: SECRET,
+  })
+  const req = new Request("http://localhost/blindpay", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "svix-id": msgId,
+      "svix-timestamp": ts,
+      "svix-signature": `v1,${sig}`,
+    },
+    body: payload,
+  })
+  // Capture waitUntil-scheduled dispatch so we can await it deterministically.
+  const tasks: Promise<unknown>[] = []
+  const ctx = {
+    waitUntil: (p: Promise<unknown>) => tasks.push(p),
+    passThroughOnException: () => {},
+  }
+  const res = await webhooks.fetch(req, env, ctx as unknown as ExecutionContext)
+  await Promise.all(tasks)
+  return res
+}
+
+describe("POST /webhooks/blindpay — flat BlindPay payload", () => {
+  it("reads the event type from `webhook_event` (not `event_type`)", async () => {
+    const res = await postWebhook({
+      webhook_event: "receiver.update",
+      id: RECEIVER_ID,
+      email: "gui.rodz.dev@gmail.com",
+      kyc_status: "verifying",
+      country: "BR",
+    })
+    expect(res.status).toBe(200)
+    const row = await db
+      .select({ eventType: webhookEvents.eventType })
+      .from(webhookEvents)
+      .where(eq(webhookEvents.id, "msg_test00000001"))
+      .get()
+    // The bug stored "unknown" here for every event.
+    expect(row?.eventType).toBe("receiver.update")
+  })
+
+  it("routes a flat receiver.update to the state machine (verifying -> pending stays pending)", async () => {
+    const res = await postWebhook({
+      webhook_event: "receiver.update",
+      id: RECEIVER_ID,
+      email: "gui.rodz.dev@gmail.com",
+      kyc_status: "verifying",
+      country: "BR",
+    })
+    expect(res.status).toBe(200)
+    const profile = await db
+      .select({ state: userProfile.onboardingState })
+      .from(userProfile)
+      .where(eq(userProfile.userId, USER_ID))
+      .get()
+    expect(profile?.state).toBe("pending")
+    const row = await db
+      .select({ processedAt: webhookEvents.processedAt, error: webhookEvents.error })
+      .from(webhookEvents)
+      .where(eq(webhookEvents.id, "msg_test00000001"))
+      .get()
+    expect(row?.error).toBeNull()
+    expect(row?.processedAt).not.toBeNull()
+  })
+})

--- a/apps/cli/src/commands/onboard.ts
+++ b/apps/cli/src/commands/onboard.ts
@@ -1,6 +1,16 @@
+import { createInterface } from "node:readline/promises"
 import { z } from "zod"
 import { loadCredentials } from "../lib/credentials"
 import { openBrowser } from "../lib/browser"
+
+async function promptLine(question: string): Promise<string> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout })
+  try {
+    return (await rl.question(question)).trim()
+  } finally {
+    rl.close()
+  }
+}
 
 const StartResponse = z.object({
   state: z.enum(["none", "pending", "approved", "rejected", "ready"]),
@@ -20,15 +30,20 @@ export async function onboard(opts: OnboardOptions = {}): Promise<number> {
     return 3
   }
 
+  // A referral code is required to onboard. Prompt for it when not passed via
+  // --referral and we're in an interactive (non-JSON) session.
+  let referralCode = opts.referralCode
+  if (!referralCode && !opts.json) {
+    referralCode = (await promptLine("Referral code: ")) || undefined
+  }
+
   const startRes = await fetch(`${creds.apiUrl}/onboard/start`, {
     method: "POST",
     headers: {
       Authorization: `Bearer ${creds.sessionToken}`,
       "Content-Type": "application/json",
     },
-    body: JSON.stringify(
-      opts.referralCode ? { referralCode: opts.referralCode } : {},
-    ),
+    body: JSON.stringify(referralCode ? { referralCode } : {}),
   })
 
   if (startRes.status === 401) {
@@ -38,11 +53,13 @@ export async function onboard(opts: OnboardOptions = {}): Promise<number> {
   if (startRes.status === 400 || startRes.status === 409) {
     const body = (await startRes.json().catch(() => ({}))) as { error?: string }
     const msg =
-      body.error === "self_referral"
-        ? "You can't use your own referral code."
-        : body.error === "code_taken"
-          ? "That referral code was already used."
-          : "Invalid referral code."
+      body.error === "referral_required"
+        ? "A referral code is required to onboard. Run `bulma onboard --referral <code>`."
+        : body.error === "self_referral"
+          ? "You can't use your own referral code."
+          : body.error === "code_taken"
+            ? "That referral code was already used."
+            : "Invalid referral code."
     console.error(msg)
     return 4
   }


### PR DESCRIPTION
## Why

Two production bugs surfaced by the first users:

1. **Anyone could onboard with no referral code.** `/onboard/start` treated `referralCode` as optional and skipped the entire referral block when absent. The first user onboarded with no code at all.
2. **Approved users stuck at `pending`.** BlindPay webhooks were received + signature-verified, but parsed in the wrong shape — type read from `event_type` (BlindPay uses `webhook_event`) and fields read from a nested `data` envelope (BlindPay is flat). Every event resolved to `"unknown"`, hit the dispatch `default`, and was marked processed with no error. `receiver.update` (kyc approved) never reached the state machine. Affected **every user**.

## What

- **webhooks**: read type from `webhook_event` (fallback `event_type`); flatten `ReceiverEventSchema`/`PayoutEventSchema`/`TosEventSchema`; parse `kyc_status` leniently (unmodeled status → `pending`, never a parse failure).
- **onboard**: referral code now mandatory → missing = `400 referral_required`. Users who already attached on an earlier `/start` are exempt (no lock-out on re-run).
- **CLI**: `bulma onboard` prompts for the code before minting the KYC link.
- **tests**: route-level coverage for both the webhook wire format and the referral gate. Suite 99/99 green, typecheck clean.

## Ops notes

- 5 ownerless bootstrap referral codes already seeded to prod D1 (script included under `apps/api/scripts/`).
- After deploy, the first user's `receiver.update` must be **re-triggered** from BlindPay — the 7 already-stored events are marked processed and the cron redispatch reuses the stale stored `event_type`, so they are not auto-recoverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)