### PR TITLE
fix(onboard): always provision virtual account regardless of receiver country

### DIFF
--- a/apps/api/scripts/recover-gui-onboarding.sql
+++ b/apps/api/scripts/recover-gui-onboarding.sql
@@ -1,0 +1,19 @@
+-- One-off recovery: the first user (gui.rodz.dev) was approved by BlindPay, but
+-- the receiver.update webhook predated the webhook-parsing fix and was dropped
+-- as "unknown". Svix replays reuse the same svix-id, so the stale event can't be
+-- reprocessed through the dedup guard. Reconstruct the ready state directly from
+-- the verified webhook payloads (managed wallet bl_, AA bridge bw_, VA va_), then
+-- mint the user's 5 referral codes (what provisionWalletAndVirtualAccount does).
+UPDATE user_profile
+SET wallet_id='bl_mSPLIVyMZWSC',
+    wallet_address='0x1e7e919ba8c0dda1514c1ba7e6813db8715cf8e2',
+    virtual_account_id='va_tZTCSe94rcLj',
+    onboarding_state='ready'
+WHERE user_id='dB0BCiUEabeNAfB6edV9fbz5YyIfITNw';
+
+INSERT INTO referral_codes (id, owner_user_id, code, status, created_at) VALUES
+  ('rc_L7drJebkzrQL', 'dB0BCiUEabeNAfB6edV9fbz5YyIfITNw', 'JRHT8Z', 'available', 1780192832),
+  ('rc_erk_pWR3eEME', 'dB0BCiUEabeNAfB6edV9fbz5YyIfITNw', 'XNP4YD', 'available', 1780192832),
+  ('rc_e-urm4VpjTWm', 'dB0BCiUEabeNAfB6edV9fbz5YyIfITNw', '7JTT4B', 'available', 1780192832),
+  ('rc_jY1rYqb2UiL8', 'dB0BCiUEabeNAfB6edV9fbz5YyIfITNw', 'ZRVVEY', 'available', 1780192832),
+  ('rc_OJ_KF3mdWoW2', 'dB0BCiUEabeNAfB6edV9fbz5YyIfITNw', 'ACQ7Y2', 'available', 1780192832);

--- a/apps/api/src/lib/onboard.ts
+++ b/apps/api/src/lib/onboard.ts
@@ -34,13 +34,16 @@ export function pickManagedWallet(
 }
 
 /**
- * Virtual accounts are US-only (SSN/EIN). Missing country → attempt (BlindPay is
- * the final arbiter); an explicit non-US country → skip the VA step entirely.
+ * Every receiver gets a US virtual account: BlindPay always issues it in the US
+ * (jpmorgan) regardless of the receiver's own country (BR, AR, US, …). So the
+ * VA step is always attempted — the receiver's country is irrelevant, and
+ * BlindPay is the final arbiter. The `country` arg is kept for call-site
+ * compatibility but no longer gates eligibility.
  */
 export function isVirtualAccountEligible(
-  country: string | null | undefined,
+  _country: string | null | undefined,
 ): boolean {
-  return country == null || country.toUpperCase() === "US"
+  return true
 }
 
 const VirtualAccountPlanSchema = z.discriminatedUnion("kind", [

--- a/apps/api/tests/onboard.test.ts
+++ b/apps/api/tests/onboard.test.ts
@@ -24,19 +24,14 @@ describe('pickManagedWallet', () => {
 });
 
 describe('isVirtualAccountEligible', () => {
-  it('attempts when country is unknown (null/undefined)', () => {
+  it('is eligible regardless of country (BlindPay always issues a US VA)', () => {
     expect(isVirtualAccountEligible(null)).toBe(true);
     expect(isVirtualAccountEligible(undefined)).toBe(true);
-  });
-
-  it('is eligible for US, case-insensitive', () => {
     expect(isVirtualAccountEligible('US')).toBe(true);
     expect(isVirtualAccountEligible('us')).toBe(true);
-  });
-
-  it('skips an explicit non-US country', () => {
-    expect(isVirtualAccountEligible('BR')).toBe(false);
-    expect(isVirtualAccountEligible('GB')).toBe(false);
+    expect(isVirtualAccountEligible('BR')).toBe(true);
+    expect(isVirtualAccountEligible('AR')).toBe(true);
+    expect(isVirtualAccountEligible('GB')).toBe(true);
   });
 });
 

--- a/apps/api/tests/webhooks-provision.test.ts
+++ b/apps/api/tests/webhooks-provision.test.ts
@@ -24,19 +24,13 @@ describe('pickManagedWallet (idempotency: no double-provisioning)', () => {
 });
 
 describe('isVirtualAccountEligible', () => {
-  it('US (any case) is eligible', () => {
+  it('is eligible for any country (BlindPay always issues a US VA)', () => {
     expect(isVirtualAccountEligible('US')).toBe(true);
     expect(isVirtualAccountEligible('us')).toBe(true);
-  });
-
-  it('missing country attempts (BlindPay is the final arbiter)', () => {
     expect(isVirtualAccountEligible(undefined)).toBe(true);
     expect(isVirtualAccountEligible(null)).toBe(true);
-  });
-
-  it('explicit non-US is ineligible', () => {
-    expect(isVirtualAccountEligible('BR')).toBe(false);
-    expect(isVirtualAccountEligible('MX')).toBe(false);
+    expect(isVirtualAccountEligible('BR')).toBe(true);
+    expect(isVirtualAccountEligible('MX')).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Why

BlindPay always issues the virtual account in the **US (jpmorgan)** for every receiver — regardless of the receiver's own country (BR, AR, US, …). The end customer always sees a US VA.

`isVirtualAccountEligible` gated on country (`US`/unknown only), so a non-US receiver reached `ready` with the VA step **skipped** (`pickVirtualAccountPlan` → `skip`) and `virtual_account_id = NULL` — i.e. unable to receive. This is exactly why the first user (gui, `BR`) had no VA attached until it was done manually.

## What

- `isVirtualAccountEligible` is now unconditional — country no longer gates VA provisioning. BlindPay is the final arbiter; the only remaining skip is a missing wallet address (already guarded in `pickVirtualAccountPlan`).
- Updated unit tests (BR/AR/MX now eligible).
- Includes the one-off prod recovery script used to re-attach the first user's VA from the verified webhook payloads.

Suite green, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)