### PR TITLE
feat(account): show full bank details for salary payers

### DIFF
--- a/apps/api/src/lib/blindpay.ts
+++ b/apps/api/src/lib/blindpay.ts
@@ -50,6 +50,22 @@ const UsRailSchema = z
   })
   .passthrough()
 
+// Beneficiary (account holder) and receiving-bank parties. The payer needs the
+// full name + address of both to wire salary. Every field is optional — BlindPay
+// only populates what the banking partner returns — and passthrough preserves
+// anything we don't model.
+const UsPartySchema = z
+  .object({
+    name: z.string().nullable().optional(),
+    address_line_1: z.string().nullable().optional(),
+    address_line_2: z.string().nullable().optional(),
+    city: z.string().nullable().optional(),
+    state_province_region: z.string().nullable().optional(),
+    country: z.string().nullable().optional(),
+    postal_code: z.string().nullable().optional(),
+  })
+  .passthrough()
+
 const VirtualAccountResponse = z
   .object({
     id: z.string(),
@@ -64,8 +80,8 @@ const VirtualAccountResponse = z
         wire: UsRailSchema.optional(),
         rtp: UsRailSchema.optional(),
         swift_bic_code: z.string().optional(),
-        beneficiary: z.unknown().optional(),
-        receiving_bank: z.unknown().optional(),
+        beneficiary: UsPartySchema.optional(),
+        receiving_bank: UsPartySchema.optional(),
         account_type: z.string().optional(),
       })
       .passthrough()

--- a/apps/api/src/routes/accounts.ts
+++ b/apps/api/src/routes/accounts.ts
@@ -22,6 +22,16 @@ type BlindPayRail = {
   account_number?: string
 }
 
+type BlindPayParty = {
+  name?: string | null
+  address_line_1?: string | null
+  address_line_2?: string | null
+  city?: string | null
+  state_province_region?: string | null
+  country?: string | null
+  postal_code?: string | null
+}
+
 function maskAccountNumber(n: string | undefined): string | null {
   if (!n) return null
   if (n.length <= 4) return n
@@ -34,13 +44,25 @@ const RailResponse = z.object({
   accountNumberMasked: z.string().nullable(),
 })
 
+const PartyResponse = z.object({
+  name: z.string().nullable(),
+  addressLine1: z.string().nullable(),
+  addressLine2: z.string().nullable(),
+  city: z.string().nullable(),
+  stateProvinceRegion: z.string().nullable(),
+  country: z.string().nullable(),
+  postalCode: z.string().nullable(),
+})
+
 const VirtualAccountResponse = z
   .object({
     status: z.string().nullable(),
     ach: RailResponse.nullable(),
     wire: RailResponse.nullable(),
     rtp: RailResponse.nullable(),
-    beneficiary: z.unknown().nullable(),
+    swiftBicCode: z.string().nullable(),
+    beneficiary: PartyResponse.nullable(),
+    receivingBank: PartyResponse.nullable(),
     accountType: z.string().nullable(),
   })
   .openapi("AccountVirtualResponse")
@@ -115,13 +137,27 @@ accounts.openapi(virtualRoute, async (c) => {
             accountNumberMasked: maskAccountNumber(r.account_number),
           }
         : null
+    const party = (p: BlindPayParty | undefined) =>
+      p
+        ? {
+            name: p.name ?? null,
+            addressLine1: p.address_line_1 ?? null,
+            addressLine2: p.address_line_2 ?? null,
+            city: p.city ?? null,
+            stateProvinceRegion: p.state_province_region ?? null,
+            country: p.country ?? null,
+            postalCode: p.postal_code ?? null,
+          }
+        : null
     return c.json(
       {
         status: va.kyc_status ?? va.status ?? null,
         ach: rail(va.us?.ach),
         wire: rail(va.us?.wire),
         rtp: rail(va.us?.rtp),
-        beneficiary: va.us?.beneficiary ?? null,
+        swiftBicCode: va.us?.swift_bic_code ?? null,
+        beneficiary: party(va.us?.beneficiary),
+        receivingBank: party(va.us?.receiving_bank),
         accountType: va.us?.account_type ?? null,
       },
       200,

--- a/apps/cli/src/commands/account.ts
+++ b/apps/cli/src/commands/account.ts
@@ -49,7 +49,7 @@ function printRail(label: string, rail: RailValue): void {
 
 function printParty(label: string, party: PartyValue): void {
   if (!party) return
-  const lines = [
+  const candidates = [
     party.name,
     party.addressLine1,
     party.addressLine2,
@@ -57,7 +57,11 @@ function printParty(label: string, party: PartyValue): void {
       .filter(Boolean)
       .join(", "),
     party.country,
-  ].filter((l): l is string => !!l && l.trim().length > 0)
+  ]
+  const lines: string[] = []
+  for (const c of candidates) {
+    if (c && c.trim().length > 0) lines.push(c)
+  }
   if (lines.length === 0) return
   console.log(`${label}`)
   for (const line of lines) console.log(`  ${line}`)

--- a/apps/cli/src/commands/account.ts
+++ b/apps/cli/src/commands/account.ts
@@ -9,30 +9,58 @@ const Rail = z
   })
   .nullable()
 
+const Party = z
+  .object({
+    name: z.string().nullable(),
+    addressLine1: z.string().nullable(),
+    addressLine2: z.string().nullable(),
+    city: z.string().nullable(),
+    stateProvinceRegion: z.string().nullable(),
+    country: z.string().nullable(),
+    postalCode: z.string().nullable(),
+  })
+  .nullable()
+
 const VirtualAccountResponse = z.object({
   status: z.string().nullable(),
   ach: Rail,
   wire: Rail,
   rtp: Rail,
-  beneficiary: z.unknown().nullable(),
+  swiftBicCode: z.string().nullable(),
+  beneficiary: Party,
+  receivingBank: Party,
   accountType: z.string().nullable(),
 })
 
 type RailValue = z.infer<typeof Rail>
+type PartyValue = z.infer<typeof Party>
 
 type AccountOptions = {
-  showFull?: boolean
   json?: boolean
 }
 
-function printRail(label: string, rail: RailValue, showFull: boolean): void {
+function printRail(label: string, rail: RailValue): void {
   if (!rail) return
-  const acct = showFull
-    ? (rail.accountNumber ?? rail.accountNumberMasked ?? "—")
-    : (rail.accountNumberMasked ?? "—")
+  const acct = rail.accountNumber ?? rail.accountNumberMasked ?? "—"
   console.log(`${label}`)
   console.log(`  Routing number:  ${rail.routingNumber ?? "—"}`)
   console.log(`  Account number:  ${acct}`)
+}
+
+function printParty(label: string, party: PartyValue): void {
+  if (!party) return
+  const lines = [
+    party.name,
+    party.addressLine1,
+    party.addressLine2,
+    [party.city, party.stateProvinceRegion, party.postalCode]
+      .filter(Boolean)
+      .join(", "),
+    party.country,
+  ].filter((l): l is string => !!l && l.trim().length > 0)
+  if (lines.length === 0) return
+  console.log(`${label}`)
+  for (const line of lines) console.log(`  ${line}`)
 }
 
 export async function account(opts: AccountOptions = {}): Promise<number> {
@@ -42,9 +70,7 @@ export async function account(opts: AccountOptions = {}): Promise<number> {
     return 3
   }
 
-  const url = `${creds.apiUrl}/accounts/virtual${
-    opts.showFull ? "?reveal=1" : ""
-  }`
+  const url = `${creds.apiUrl}/accounts/virtual?reveal=1`
   const res = await fetch(url, {
     headers: { Authorization: `Bearer ${creds.sessionToken}` },
   })
@@ -76,12 +102,13 @@ export async function account(opts: AccountOptions = {}): Promise<number> {
 
   console.log("US Account")
   console.log("==========")
-  printRail("ACH", va.ach, !!opts.showFull)
-  printRail("Wire", va.wire, !!opts.showFull)
-  printRail("RTP", va.rtp, !!opts.showFull)
+  printRail("ACH", va.ach)
+  printRail("Wire", va.wire)
+  printRail("RTP", va.rtp)
   if (va.accountType) console.log(`Account type:    ${va.accountType}`)
-  if (!opts.showFull) {
-    console.log("(run `bulma account --show-full` to reveal full numbers)")
-  }
+  if (va.swiftBicCode) console.log(`SWIFT/BIC:       ${va.swiftBicCode}`)
+  if (va.beneficiary || va.receivingBank) console.log("")
+  printParty("Beneficiary", va.beneficiary)
+  printParty("Receiving bank", va.receivingBank)
   return 0
 }

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -31,7 +31,6 @@ Commands:
     --no-browser      Do not auto-open the browser
     --json            Machine-readable output
   account             Show US account instructions
-    --show-full       Reveal the full account number
     --json            Machine-readable output
   balance             Show account balance in USD
     --json            Machine-readable output
@@ -95,7 +94,6 @@ async function main(argv: string[]): Promise<number> {
       })
     case "account":
       return account({
-        showFull: hasFlag(rest, "show-full"),
         json: hasFlag(rest, "json"),
       })
     case "balance":


### PR DESCRIPTION
## Why

Remote workers run `bulma account` to get the bank details they forward to a payer to **receive salary**. The command was hiding most of what a payer needs:

- Account numbers were masked behind a `--show-full` flag
- `beneficiary` was typed `z.unknown()` and shown as nothing useful
- `swift_bic_code` and `receiving_bank` were never propagated from BlindPay

A payer cannot complete a wire without the beneficiary name + address, receiving-bank name + address, SWIFT/BIC, and the **full** account number.

## What

`bulma account` now displays everything:

```
US Account
==========
ACH
  Routing number:  ...
  Account number:  <full>
Wire
  Routing number:  ...
  Account number:  <full>
RTP
  ...
Account type:    checking
SWIFT/BIC:       ...

Beneficiary
  <name>
  <address>
Receiving bank
  <bank name>
  <bank address>
```

### Layers
- **`blindpay.ts`** — type `beneficiary` + `receiving_bank` as structured parties (name + full address), was `z.unknown()`
- **`accounts.ts`** (`GET /accounts/virtual`) — propagate `swiftBicCode`, `beneficiary`, `receivingBank`
- **`account.ts`** (CLI) — display all fields; always request `?reveal=1` and print full account numbers
- **`index.ts`** — drop the `--show-full` flag (no longer needed)

## Notes
- BlindPay's `beneficiary`/`receiving_bank` shape is modeled all-optional + passthrough, so parsing never breaks and empty parties skip cleanly. Worth confirming field names against a live `getVirtualAccount` response.
- API keeps the `reveal` query gate for any non-CLI caller; the CLI always sends `reveal=1`.

## Test
- `bun run typecheck` clean (api + cli)
- `bun test` — 95 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)