### PR TITLE
docs(readme): fix Hermes install command to resolve by repo path

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ Your agent can now call `bulma <command> --json`.
 
 ### Hermes
 
-Install the bulma skill ([skills live in `~/.hermes/skills/`](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills)):
+Install the bulma skill ([skills live in `~/.hermes/skills/`](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills)). A bare `hermes skills install bulma` only resolves names in the default taps and registries — bulma isn't there yet, so install it straight from this repo by path:
 
 ```sh
-hermes skills install bulma
+hermes skills install fortheordinary/bulma/apps/cli/skill
 ```
 
 Your agent can now call `bulma <command> --json`.


### PR DESCRIPTION
## Problem

A user ran `hermes skills install bulma` and got **`No skill named bulma found in any source`**.

`hermes skills install bulma` is a **bare name**. Per the [Hermes skills docs](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills), bare names resolve only against:

- official optional skills
- the skills.sh directory
- default GitHub taps (openai/anthropics/huggingface/NVIDIA/garrytan)
- user-added taps

Bulma is registered in none of them, so the documented command can never succeed. Bare names never consult arbitrary GitHub repos or well-known endpoints.

## Fix

Point users at the direct repo-path install, which Hermes resolves to the `SKILL.md` at that path (arbitrary path; no `skills/` folder required):

```sh
hermes skills install fortheordinary/bulma/apps/cli/skill
```

Repo is public; verified `apps/cli/skill/SKILL.md` returns 200 via both raw and the GitHub contents API, so Hermes can fetch it.

## Follow-ups (not in this PR)

True bare-name `hermes skills install bulma` requires registering the skill in a source Hermes searches:
- **skills.sh** — index an entry with `skillId: bulma` (cleanest via a `bul.ma` well-known endpoint, mirroring the `mintlify.com` listing).
- **Hermes official optional skills** — PR to the Nous `optional-skills/` set for built-in trust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)